### PR TITLE
Expand map and support multi-tile buildings

### DIFF
--- a/handlers/handlePointerDown.js
+++ b/handlers/handlePointerDown.js
@@ -1,22 +1,24 @@
 import Grid from "../src/game/core/Grid";
 import GameModel from "../src/game/core/GameModel";
 import Pointer from "../src/game/core/Pointer";
-import { BUILDING_TYPES } from "../src/game/core/constants";
+import { BUILDING_TYPES, BUILDING_SIZES } from "../src/game/core/constants";
 import * as House from "../src/buildings_logic/house";
 import * as TrainingCenter from "../src/buildings_logic/training_center";
 
 export default function handlePointerDown(scene, pointer) {
   const { cx, cy } = Grid.worldToCell(pointer.worldX, pointer.worldY);
-  const cell = GameModel.gridData[cy][cx];
+  const grid = GameModel.gridData;
+  const cell = grid[cy][cx];
 
   if (Pointer.selected) {
-    if (!cell.building) {
+    const { w, h } = BUILDING_SIZES[Pointer.selected];
+    if (canPlace(grid, cx, cy, w, h)) {
       switch (Pointer.selected) {
         case BUILDING_TYPES.HOUSE:
-          House.init(scene, cell, cx, cy);
+          House.init(scene, grid, cx, cy);
           break;
         case BUILDING_TYPES.TRAINING_CENTER:
-          TrainingCenter.init(scene, cell, cx, cy);
+          TrainingCenter.init(scene, grid, cx, cy);
           break;
         default:
           break;
@@ -26,14 +28,26 @@ export default function handlePointerDown(scene, pointer) {
     return;
   }
 
-  if (cell.building && !cell.isUnderConstruction) {
+  const target = cell.root || cell;
+  if (target.building && !target.isUnderConstruction) {
     const payload =
-      cell.buildingType === BUILDING_TYPES.HOUSE
-        ? House.getClickPayload(cell)
-        : cell.buildingType === BUILDING_TYPES.TRAINING_CENTER
-        ? TrainingCenter.getClickPayload(cell)
+      target.buildingType === BUILDING_TYPES.HOUSE
+        ? House.getClickPayload(target)
+        : target.buildingType === BUILDING_TYPES.TRAINING_CENTER
+        ? TrainingCenter.getClickPayload(target)
         : null;
 
     if (payload) scene.reactCallback?.(payload);
   }
+}
+
+function canPlace(grid, cx, cy, w, h) {
+  for (let dy = 0; dy < h; dy++) {
+    for (let dx = 0; dx < w; dx++) {
+      const row = grid[cy + dy];
+      const cell = row?.[cx + dx];
+      if (!cell || cell.building) return false;
+    }
+  }
+  return true;
 }

--- a/src/game/core/Pointer.js
+++ b/src/game/core/Pointer.js
@@ -1,4 +1,4 @@
-import { BUILDING_TYPES, TILE_SIZE } from "./constants";
+import { BUILDING_TYPES, BUILDING_SIZES, TILE_SIZE } from "./constants";
 
 const Pointer = {
   selected: null,
@@ -22,6 +22,8 @@ const Pointer = {
 
   setSelected(scene, type) {
     this.selected = type;
+    const { w, h } = BUILDING_SIZES[type];
+    this.preview.setSize(w * TILE_SIZE - 2, h * TILE_SIZE - 2);
     this.preview.setVisible(true);
     scene.input.setDefaultCursor("crosshair");
   },

--- a/src/game/core/PopulationSystem.js
+++ b/src/game/core/PopulationSystem.js
@@ -18,7 +18,11 @@ const PopulationSystem = {
     for (let y = 0; y < grid.length; y++) {
       for (let x = 0; x < grid[0].length; x++) {
         const cell = grid[y][x];
-        if (cell.buildingType === "house" && cell.villagers < HOUSE_CAPACITY) {
+        if (
+          cell.buildingType === "house" &&
+          cell.root === cell &&
+          cell.villagers < HOUSE_CAPACITY
+        ) {
           return { x, y, cell };
         }
       }
@@ -31,7 +35,7 @@ const PopulationSystem = {
     for (let y = 0; y < grid.length; y++) {
       for (let x = 0; x < grid[0].length; x++) {
         const cell = grid[y][x];
-        if (cell.buildingType === "house" && cell.villagers > 0) {
+        if (cell.buildingType === "house" && cell.root === cell && cell.villagers > 0) {
           cell.villagers -= 1;
           GameModel.professions[professionKey] += 1;
           return true;

--- a/src/game/core/ResourceSystem.js
+++ b/src/game/core/ResourceSystem.js
@@ -10,7 +10,11 @@ const ResourceSystem = {
       for (let y = 0; y < grid.length; y++) {
         for (let x = 0; x < grid[0].length; x++) {
           const cell = grid[y][x];
-          if (cell.buildingType === "house" && cell.villagers === HOUSE_CAPACITY) {
+          if (
+            cell.buildingType === "house" &&
+            cell.root === cell &&
+            cell.villagers === HOUSE_CAPACITY
+          ) {
             fullHouses += 1;
           }
         }

--- a/src/game/core/constants.js
+++ b/src/game/core/constants.js
@@ -1,6 +1,6 @@
-export const TILE_SIZE = 48;
-export const GRID_WIDTH = 16;
-export const GRID_HEIGHT = 10;
+export const TILE_SIZE = 8;
+export const GRID_WIDTH = 128;
+export const GRID_HEIGHT = 80;
 
 export const POPULATION_CAP_START = 10;
 export const HOUSE_CAPACITY = 4;
@@ -12,4 +12,9 @@ export const HOUSE_FULL_INCOME = 0.1;
 export const BUILDING_TYPES = {
   HOUSE: "house",
   TRAINING_CENTER: "training_center",
+};
+
+export const BUILDING_SIZES = {
+  [BUILDING_TYPES.HOUSE]: { w: 2, h: 2 },
+  [BUILDING_TYPES.TRAINING_CENTER]: { w: 3, h: 2 },
 };

--- a/src/ui/HUD.jsx
+++ b/src/ui/HUD.jsx
@@ -23,20 +23,20 @@ export default function HUD() {
     <div style={{ position: "absolute", top: 8, right: 8, background: "rgba(0,0,0,0.5)", color: "#fff", padding: "8px 12px", borderRadius: 8, fontFamily: "sans-serif", fontSize: 14 }}>
       <div><strong>Gold:</strong> {GameModel.gold.toFixed(2)}</div>
       <div><strong>Population:</strong> {p.current}/{p.cap}</div>
-      <div><strong>Free at home:</strong> {countFreeVillagers()}</div>
+      <div><strong>Villagers:</strong> {countVillagers()}</div>
       <div><strong>Farmers:</strong> {prof.farmer} &nbsp; <strong>Foresters:</strong> {prof.forester}</div>
       <div><strong>Wheat:</strong> {res.wheat} &nbsp; <strong>Wood:</strong> {res.wood}</div>
     </div>
   );
 }
 
-function countFreeVillagers() {
+function countVillagers() {
   const grid = GameModel.gridData || [];
   let n = 0;
   for (let y = 0; y < grid.length; y++) {
     for (let x = 0; x < (grid[0]?.length || 0); x++) {
       const cell = grid[y][x];
-      if (cell.buildingType === "house") n += cell.villagers;
+      if (cell.buildingType === "house" && cell.root === cell) n += cell.villagers;
     }
   }
   return n;


### PR DESCRIPTION
## Summary
- shrink tile size to 8px and expand grid to 128x80
- allow buildings to span multiple tiles; houses use 2x2 and training centers 3x2 footprints
- adjust UI and systems for new villager terminology and multi-tile logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_689ca4acd0f8832ca45fbf79d46b6236