### PR TITLE
Load saved tile allocations for map

### DIFF
--- a/src/utils/supabase.js
+++ b/src/utils/supabase.js
@@ -14,3 +14,18 @@ export async function saveTilesToSupabase(tyles) {
   }
 }
 
+export async function fetchLatestTilesFromSupabase() {
+  try {
+    const { data, error } = await supabase
+      .from("game_test")
+      .select("tyles")
+      .order("id", { ascending: false })
+      .limit(1);
+    if (error) return { data: null, error };
+    const latest = Array.isArray(data) && data.length > 0 ? data[0]?.tyles : null;
+    return { data: latest || null, error: null };
+  } catch (error) {
+    return { data: null, error };
+  }
+}
+


### PR DESCRIPTION
Load saved tile types from Supabase on map initialization to persist tile allocations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e01d121-7a69-4ed8-a84a-3d1c2fd90d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e01d121-7a69-4ed8-a84a-3d1c2fd90d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

